### PR TITLE
feat: add additionalNicsDhcp input

### DIFF
--- a/pkg/ionoscloud/machine-config/ionoscloud.vue
+++ b/pkg/ionoscloud/machine-config/ionoscloud.vue
@@ -541,9 +541,9 @@ export default defineComponent({
 
     onChangeAdditionalLansDhcp(event) {
       for (let el of event) {
-        let spl = el.split('=');
+        let spl = el.split(':');
         if (spl.length != 2 || Number.isNaN(parseInt(spl[0])) || !['true', 'false'].includes(spl[1].trim().toLowerCase())) {
-          alert('Invalid entry detected: ' + el + '. The accepted format is LAN_ID=true/false (e.g. 5=false)!');
+          alert('Invalid entry detected: ' + el + '. The accepted format is LAN_ID:true/false (e.g. 5:false)!');
           return;
         }
       }
@@ -1086,7 +1086,7 @@ export default defineComponent({
             :disabled="busy"
             @change="onChangeAdditionalLansDhcp($event)"
           />
-          <p class="help-block">Optional. Per-additional-LAN DHCP, as LAN_ID=true/false entries (e.g. 5=false). Additional LANs not listed keep DHCP on. Does not affect the primary NIC, which uses "NIC DHCP".</p>
+          <p class="help-block">Optional. Per-additional-LAN DHCP, as LAN_ID:true/false entries (e.g. 5:false). Additional LANs not listed keep DHCP on. Does not affect the primary NIC, which uses "NIC DHCP".</p>
         </div>
         <div class="col span-4">
           <StringList

--- a/pkg/ionoscloud/machine-config/ionoscloud.vue
+++ b/pkg/ionoscloud/machine-config/ionoscloud.vue
@@ -456,7 +456,7 @@ export default defineComponent({
       nicIps:                      this.value?.nicIps || [],
       additionalLans:              this.value?.additionalLans || [],
       additionalLansIds:           this.value?.additionalLansIds || [],
-      additionalNicsDhcp:          this.value?.additionalNicsDhcp || [],
+      additionalLansDhcp:          this.value?.additionalLansDhcp || [],
       additionalDisks:             this.value?.additionalDisks || [],
       waitForIpChange:             this.value?.waitForIpChange || false,
       waitForIpChangeTimeout:      this.value?.waitForIpChangeTimeout || '600',
@@ -539,7 +539,7 @@ export default defineComponent({
       this.additionalLansIds = event;
     },
 
-    onChangeAdditionalNicsDhcp(event) {
+    onChangeAdditionalLansDhcp(event) {
       for (let el of event) {
         let spl = el.split('=');
         if (spl.length != 2 || Number.isNaN(parseInt(spl[0])) || !['true', 'false'].includes(spl[1].trim().toLowerCase())) {
@@ -548,7 +548,7 @@ export default defineComponent({
         }
       }
 
-      this.additionalNicsDhcp = event;
+      this.additionalLansDhcp = event;
     },
 
     onChangeAdditionalDisks(event) {
@@ -774,7 +774,7 @@ export default defineComponent({
       this.value.nicIps = this.nicIps;
       this.value.additionalLans = this.additionalLans;
       this.value.additionalLansIds = this.additionalLansIds;
-      this.value.additionalNicsDhcp = this.additionalNicsDhcp;
+      this.value.additionalLansDhcp = this.additionalLansDhcp;
       this.value.additionalDisks = this.additionalDisks;
       this.value.waitForIpChange = this.waitForIpChange;
       this.value.waitForIpChangeTimeout = this.waitForIpChangeTimeout;
@@ -1079,14 +1079,14 @@ export default defineComponent({
         </div>
         <div class="col span-4">
           <StringList
-            label="Additional NICs DHCP"
-            v-model:value="additionalNicsDhcp"
-            :items="additionalNicsDhcp"
+            label="Additional LANs DHCP"
+            v-model:value="additionalLansDhcp"
+            :items="additionalLansDhcp"
             :mode="mode"
             :disabled="busy"
-            @change="onChangeAdditionalNicsDhcp($event)"
+            @change="onChangeAdditionalLansDhcp($event)"
           />
-          <p class="help-block">Optional. Per-additional-NIC DHCP, as LAN_ID=true/false entries (e.g. 5=false). Additional LANs not listed keep DHCP on. Does not affect the primary NIC, which uses "NIC DHCP".</p>
+          <p class="help-block">Optional. Per-additional-LAN DHCP, as LAN_ID=true/false entries (e.g. 5=false). Additional LANs not listed keep DHCP on. Does not affect the primary NIC, which uses "NIC DHCP".</p>
         </div>
         <div class="col span-4">
           <StringList

--- a/pkg/ionoscloud/machine-config/ionoscloud.vue
+++ b/pkg/ionoscloud/machine-config/ionoscloud.vue
@@ -250,7 +250,7 @@ function validateIp(ip) {
 
 function validateSubnet(subnet) {
   let splitSubnet = subnet.split('/')
-  return (splitSubnet.length == 2 && validateIp(splitSubnet[0]) && !(Number.isNaN(parseInt(splitSubnet[1]))));
+  return (splitSubnet.length == 2 && validateIp(splitSubnet[0]) && /^\d+$/.test(splitSubnet[1].trim()));
 }
 
 
@@ -530,7 +530,7 @@ export default defineComponent({
 
     onChangeAdditionalLansIds(event) {
       for (let id of event) {
-        if (Number.isNaN(parseInt(id))) {
+        if (!/^\d+$/.test(id.trim())) {
           alert('Invalid LAN ID detected: ' + id );
           return;
         }
@@ -542,7 +542,7 @@ export default defineComponent({
     onChangeAdditionalLansDhcp(event) {
       for (let el of event) {
         let spl = el.split(':');
-        if (spl.length != 2 || Number.isNaN(parseInt(spl[0])) || !['true', 'false'].includes(spl[1].trim().toLowerCase())) {
+        if (spl.length !== 2 || !/^\d+$/.test(spl[0].trim()) || !['true', 'false'].includes(spl[1].trim().toLowerCase())) {
           alert('Invalid entry detected: ' + el + '. The accepted format is LAN_ID:true/false (e.g. 5:false)!');
           return;
         }
@@ -567,7 +567,7 @@ export default defineComponent({
         ADDITIONAL_DISK_TYPE_OPTIONS.map((val) => {return val.value.value})
 
         let diskSize = spl[1]
-        if (Number.isNaN(parseInt(diskSize))) {
+        if (!/^\d+$/.test(diskSize.trim())) {
           alert('Invalid disk size detected: ' + diskSize );
           return;
         }
@@ -596,7 +596,7 @@ export default defineComponent({
           return;
         }
         let lanId = spl[0]
-        if (Number.isNaN(parseInt(lanId))) {
+        if (!/^\d+$/.test(lanId.trim())) {
           alert('Invalid LAN ID detected: ' + lanId );
           return;
         }

--- a/pkg/ionoscloud/machine-config/ionoscloud.vue
+++ b/pkg/ionoscloud/machine-config/ionoscloud.vue
@@ -456,6 +456,7 @@ export default defineComponent({
       nicIps:                      this.value?.nicIps || [],
       additionalLans:              this.value?.additionalLans || [],
       additionalLansIds:           this.value?.additionalLansIds || [],
+      additionalNicsDhcp:          this.value?.additionalNicsDhcp || [],
       additionalDisks:             this.value?.additionalDisks || [],
       waitForIpChange:             this.value?.waitForIpChange || false,
       waitForIpChangeTimeout:      this.value?.waitForIpChangeTimeout || '600',
@@ -536,6 +537,18 @@ export default defineComponent({
       }
 
       this.additionalLansIds = event;
+    },
+
+    onChangeAdditionalNicsDhcp(event) {
+      for (let el of event) {
+        let spl = el.split('=');
+        if (spl.length != 2 || Number.isNaN(parseInt(spl[0])) || !['true', 'false'].includes(spl[1].trim().toLowerCase())) {
+          alert('Invalid entry detected: ' + el + '. The accepted format is LAN_ID=true/false (e.g. 5=false)!');
+          return;
+        }
+      }
+
+      this.additionalNicsDhcp = event;
     },
 
     onChangeAdditionalDisks(event) {
@@ -761,6 +774,7 @@ export default defineComponent({
       this.value.nicIps = this.nicIps;
       this.value.additionalLans = this.additionalLans;
       this.value.additionalLansIds = this.additionalLansIds;
+      this.value.additionalNicsDhcp = this.additionalNicsDhcp;
       this.value.additionalDisks = this.additionalDisks;
       this.value.waitForIpChange = this.waitForIpChange;
       this.value.waitForIpChangeTimeout = this.waitForIpChangeTimeout;
@@ -1065,6 +1079,17 @@ export default defineComponent({
         </div>
         <div class="col span-4">
           <StringList
+            label="Additional NICs DHCP"
+            v-model:value="additionalNicsDhcp"
+            :items="additionalNicsDhcp"
+            :mode="mode"
+            :disabled="busy"
+            @change="onChangeAdditionalNicsDhcp($event)"
+          />
+          <p class="help-block">Optional. Per-additional-NIC DHCP, as LAN_ID=true/false entries (e.g. 5=false). Additional LANs not listed keep DHCP on. Does not affect the primary NIC, which uses "NIC DHCP".</p>
+        </div>
+        <div class="col span-4">
+          <StringList
             label="NIC Ips"
             v-model:value="nicIps"
             :items="nicIps"
@@ -1074,6 +1099,9 @@ export default defineComponent({
           />
           <p class="help-block">Optional. IPBlock reserved IPs. If not set, the driver will reserve an IPBlock automatically or let the API set a private IP if the LAN is private</p>
         </div>
+      </div>
+
+      <div class="row mt-10">
         <div class="col span-4">
           <Checkbox
             label="NIC Multi Queue"
@@ -1083,9 +1111,6 @@ export default defineComponent({
           />
           <p class="help-block">Activate or deactivate the Multi Queue feature on all NICs of this server.</p>
         </div>
-      </div>
-
-      <div class="row mt-10">
         <div class="col span-4">
           <Checkbox
             label="Wait for NIC IP change"

--- a/pkg/ionoscloud/package.json
+++ b/pkg/ionoscloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ionoscloud",
   "description": "Adds Machine Config and Cloud Credeantials for the ionoscloud rancher driver",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "icon": "https://raw.githubusercontent.com/ionos-cloud/ui-extensions-ionoscloud/main/pkg/ionoscloud/ionos.svg",
   "rancher": {


### PR DESCRIPTION
Adds an "Additional NICs DHCP" field (a list of LAN_ID=true/false entries, e.g. 5=false) mapping to the driver's --ionoscloud-additional-nics-dhcp flag, so DHCP can be configured per additional NIC. Placed after "NIC DHCP".